### PR TITLE
Fix broken escape key issue

### DIFF
--- a/OfDungeonsDeep/Windows/DexWindow.cs
+++ b/OfDungeonsDeep/Windows/DexWindow.cs
@@ -26,10 +26,8 @@ public class DexWindow : DeepDungeonWindow {
         Flags |= ImGuiWindowFlags.NoScrollWithMouse;
     }
 
-    public override bool DrawConditions() {
-        if (!Plugin.StorageManager.DataReady) return false;
-
-        return true;
+    public override void PreOpenCheck() {
+        if (IsOpen && !Plugin.StorageManager.DataReady) IsOpen = false;
     }
 
     public override void Draw() {

--- a/OfDungeonsDeep/Windows/FloorDataWindow.cs
+++ b/OfDungeonsDeep/Windows/FloorDataWindow.cs
@@ -28,7 +28,13 @@ public class FloorDataWindow : DeepDungeonWindow {
         }
     }
 
-    public override bool DrawConditions() {
+    public override void PreOpenCheck() {
+        if (IsOpen && !CanOpen()) {
+            IsOpen = false;
+        }
+    }
+
+    public bool CanOpen() {
         if (floorSet is null) return false;
         if (!Plugin.InDeepDungeon()) return false;
         if (!Plugin.Configuration.EnableFloorWindow) return false;


### PR DESCRIPTION
**Conditions for this to happen**

1. The "Use escape to close Dalamud windows" Dalamud setting must be checked.
2. The floor guide window is focused and then closed by clicking the "X".

**Why this happens**

Dalamud checks focus state like this:

```cs
        this.PreOpenCheck();

        var doSoundEffects = configuration?.EnablePluginUISoundEffects ?? false;

        if (!this.IsOpen)
        {
            if (this.internalIsOpen != this.internalLastIsOpen)
            {
                this.internalLastIsOpen = this.internalIsOpen;
                this.OnClose();

                this.IsFocused = false;
                
                if (doSoundEffects && !this.DisableWindowSounds) UIModule.PlaySound(this.OnCloseSfxId, 0, 0, 0);
            }

            return;
        }

        this.Update();
        if (!this.DrawConditions())
            return;
```

Importantly the check for "drawability" is checked after the check for "openness". Because we close the window by returning false from `DrawConditions`, Dalamud doesn't realise our window is closed and it becomes stuck as a focused window in `FocusedWindowSystemNamespace`.

This could potentially be addressed in Dalamud as well (a non-drawn window should probably not be considered focused) but anyway, this fixes the issue from the plugin side for now by using `PreOpenCheck` instead of `DrawConditions` for hiding/closing windows.